### PR TITLE
flakeify

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import HasktorchSkeleton
+
+main :: IO ()
+main = putStrLn "Hello Hasktorch!"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "hackageSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621386693,
+        "narHash": "sha256-iDI16Wc28HOuvnab2vsuCku7XqVBeVWABRZEyhSQ2RM=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "1ca8be1a4695af150ae81e6c9a2fad068c03c008",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2009": "nixpkgs-2009",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      },
+      "locked": {
+        "lastModified": 1621386783,
+        "narHash": "sha256-s25SqEJfUuIvW3vGclNU/cLwRjLbctOGPhS1ceDOwoY=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "125fb28555bf7da35b19d75766da1933861c280f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "libtorch-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621467457,
+        "narHash": "sha256-EX9gbDxio9/2LkepDKOcrAvzBRF89Ppn4ao6SExXXcw=",
+        "owner": "hasktorch",
+        "repo": "libtorch-nix",
+        "rev": "d14b0fd10b96d192b92b8ccc7254ade4b3489331",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hasktorch",
+        "repo": "libtorch-nix",
+        "rev": "d14b0fd10b96d192b92b8ccc7254ade4b3489331",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1608007629,
+        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1607708579,
+        "narHash": "sha256-QyADEDydJJPa8n3xawnA82IJAcZHNNm6Pp5DU7exMr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2009": {
+      "locked": {
+        "lastModified": 1608007629,
+        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1612284693,
+        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1621433235,
+        "narHash": "sha256-eSBLBQxJoEIFVuBgxi0vLvVVyv+BS5YAC47a2rePw9Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6cf64704297f60ca6ab579a4135bb565bb514b06",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "hackageSrc": "hackageSrc",
+        "haskell-nix": "haskell-nix",
+        "libtorch-nix": "libtorch-nix",
+        "nixpkgs": "nixpkgs_2",
+        "stackageSrc": "stackageSrc",
+        "utils": "utils"
+      }
+    },
+    "stackageSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621299779,
+        "narHash": "sha256-zAu9jI9QWZhYWc+6l2gAPWKkkcO6DpX3MnYn8ftYaAU=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "d387a944749263e4685cb116893c5226cd9fc75b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  inputs = {
+    haskell-nix.url = "github:input-output-hk/haskell.nix";
+    stackageSrc = {
+      url = "github:input-output-hk/stackage.nix";
+      flake = false;
+    };
+    hackageSrc = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+    utils.url = "github:numtide/flake-utils";
+    libtorch-nix = {
+      url = "github:hasktorch/libtorch-nix/d14b0fd10b96d192b92b8ccc7254ade4b3489331";
+      flake = false;
+    };
+  };
+
+  outputs = inputs@{ self, nixpkgs, haskell-nix, utils, ... }:
+    let
+      name = "hasktorchSkeleton";
+      compiler = "ghc8104"; # Not used for `stack.yaml` based projects.
+      cudaSupport = false;
+      cudaMajorVersion = null;
+      project-name = "${name}HaskellPackages";
+
+
+      # This overlay adds our project to pkgs
+      project-overlay = final: prev: {
+        ${project-name} =
+            #assert compiler == supported-compilers;
+            final.haskell-nix.project' {
+              # 'cleanGit' cleans a source directory based on the files known by git
+              src = prev.haskell-nix.haskellLib.cleanGit {
+                inherit name;
+                src = ./.;
+              };
+
+              compiler-nix-name = compiler;
+              projectFileName = "cabal.project"; # Not used for `stack.yaml` based projects.
+              modules = [
+                # Fixes for libtorch-ffi
+                {
+                  packages.libtorch-ffi = {
+                    configureFlags = with final; [
+                      "--extra-lib-dirs=${torch}/lib"
+                      "--extra-include-dirs=${torch}/include"
+                      "--extra-include-dirs=${torch}/include/torch/csrc/api/include"
+                    ];
+                    flags = {
+                      cuda = cudaSupport;
+                      gcc = !cudaSupport && final.stdenv.hostPlatform.isDarwin;
+                    };
+                  };
+                }
+              ];
+
+            };
+
+      };
+    in
+      { overlay = final: prev: {
+          "${name}" = ("${project-name}-overlay" final prev)."${project-name}".flake {};
+        };
+      } // (utils.lib.eachSystem [ "x86_64-linux" ] (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              haskell-nix.overlay
+              (final: prev: {
+                haskell-nix = prev.haskell-nix // {
+                  sources = prev.haskell-nix.sources // {
+                    hackage = inputs.hackageSrc;
+                    stackage = inputs.stackageSrc;
+                  };
+                  modules = [
+                    # Fixes for libtorch-ffi
+                    {
+                      packages.libtorch-ffi = {
+                        configureFlags = with final; [
+                          "--extra-lib-dirs=${torch}/lib"
+                          "--extra-include-dirs=${torch}/include"
+                          "--extra-include-dirs=${torch}/include/torch/csrc/api/include"
+                        ];
+                        flags = {
+                          cuda = cudaSupport;
+                          gcc = !cudaSupport && final.stdenv.hostPlatform.isDarwin;
+                        };
+                      };
+                    }
+                  ];
+                };
+              })
+              (import ./nix/overlays/libtorch.nix { inherit inputs cudaSupport cudaMajorVersion; })
+              project-overlay
+            ];
+          };
+          flake = pkgs."${project-name}".flake {};
+        in flake // rec {
+
+          packages.example = flake.packages."${name}:exe:example";
+
+          defaultPackage = packages.example;
+
+          devShell = (import ./shell.nix {
+              inherit cudaSupport cudaMajorVersion pkgs;
+              withHoogle = false;
+            });
+        }
+        ));
+}

--- a/hasktorch-skeleton.cabal
+++ b/hasktorch-skeleton.cabal
@@ -1,4 +1,4 @@
-cabal-version:       1.24
+cabal-version:       2.2
 name:                hasktorch-skeleton
 version:             0.0.0.0
 synopsis:            See README for more info
@@ -14,13 +14,25 @@ extra-doc-files:     README.md
                    , CHANGELOG.md
 tested-with:         GHC == 8.8.3
 
+common base
+  ghc-options: -Wall -Wextra -Wno-unrecognised-pragmas -Wno-orphans
+  default-language: Haskell2010
+  build-depends:
+      base >= 4.12 && < 5
+    , hasktorch >= 0.2 && < 0.3
+
+common binary-base
+  import: base
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends: hasktorch-skeleton
+
 library
-  hs-source-dirs:    src
-  exposed-modules:   HasktorchSkeleton
+  import: base
+  exposed-modules:
+    HasktorchSkeleton
+  hs-source-dirs: src
 
-  build-depends:     base >= 4.7 && < 5
-                   , hasktorch >= 0.2 && < 0.3
-                     
-  ghc-options:       -Wall
-
-  default-language:  Haskell2010
+executable example
+  import: binary-base
+  main-is: Main.hs
+  hs-source-dirs: exe

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -42,43 +42,11 @@ let
     ++ iohkNix.overlays.haskell-nix-extra
     # the iohkNix overlay contains nix utilities and niv
     ++ iohkNix.overlays.iohkNix
-    # libtorch overlays from pytorch-world
-    # TODO: pull in libGL_driver and cudatoolkit as done in https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/katago/default.nix
     ++ [
-      (pkgs: _: with pkgs;
-        let libtorchSrc = callPackage "${sources.pytorch-world}/libtorch/release.nix" { }; in
-        if cudaSupport && cudaMajorVersion == "9" then
-          let libtorch = libtorchSrc.libtorch_cudatoolkit_9_2; in
-          {
-            c10 = libtorch;
-            torch = libtorch;
-            torch_cpu = libtorch;
-            torch_cuda = libtorch;
-          }
-        else if cudaSupport && cudaMajorVersion == "10" then
-          let libtorch = libtorchSrc.libtorch_cudatoolkit_10_2; in
-          {
-            c10 = libtorch;
-            torch = libtorch;
-            torch_cpu = libtorch;
-            torch_cuda = libtorch;
-          }
-        else if cudaSupport && cudaMajorVersion == "11" then
-          let libtorch = libtorchSrc.libtorch_cudatoolkit_11_0; in
-          {
-            c10 = libtorch;
-            torch = libtorch;
-            torch_cpu = libtorch;
-            torch_cuda = libtorch;
-          }
-        else
-          let libtorch = libtorchSrc.libtorch_cpu; in
-          {
-            c10 = libtorch;
-            torch = libtorch;
-            torch_cpu = libtorch;
-          }
-      )
+      (import ./overlays/libtorch.nix {
+        inherit cudaSupport cudaMajorVersion;
+        inputs = sources;
+      })
     ]
     # our own overlays:
     ++ [

--- a/nix/overlays/libtorch.nix
+++ b/nix/overlays/libtorch.nix
@@ -1,0 +1,41 @@
+{ inputs, cudaSupport, cudaMajorVersion ? null }:
+
+# libtorch overlays from pytorch-world
+# TODO: pull in libGL_driver and cudatoolkit as done in https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/katago/default.nix
+
+final: prev:
+with prev;
+
+let libtorchSrc = callPackage "${inputs.libtorch-nix}/libtorch/release.nix" { }; in
+
+if cudaSupport && cudaMajorVersion == "9" then
+  let libtorch = libtorchSrc.libtorch_cudatoolkit_9_2; in
+  {
+    c10 = libtorch;
+    torch = libtorch;
+    torch_cpu = libtorch;
+    torch_cuda = libtorch;
+  }
+else if cudaSupport && cudaMajorVersion == "10" then
+  let libtorch = libtorchSrc.libtorch_cudatoolkit_10_2; in
+  {
+    c10 = libtorch;
+    torch = libtorch;
+    torch_cpu = libtorch;
+    torch_cuda = libtorch;
+  }
+else if cudaSupport && cudaMajorVersion == "11" then
+  let libtorch = libtorchSrc.libtorch_cudatoolkit_11_0; in
+  {
+    c10 = libtorch;
+    torch = libtorch;
+    torch_cpu = libtorch;
+    torch_cuda = libtorch;
+  }
+else
+  let libtorch = libtorchSrc.libtorch_cpu; in
+  {
+    c10 = libtorch;
+    torch = libtorch;
+    torch_cpu = libtorch;
+  }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -47,6 +47,18 @@
         "url": "https://github.com/tweag/jupyterWith/archive/35eb565c6d00f3c61ef5e74e7e41870cfa3926f7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "libtorch-nix": {
+        "branch": "main",
+        "description": null,
+        "homepage": null,
+        "owner": "hasktorch",
+        "repo": "libtorch-nix",
+        "rev": "d14b0fd10b96d192b92b8ccc7254ade4b3489331",
+        "sha256": "1k2xax64hfmaw5kzmx3w242z62xckjihraa75vvdz8v27in60zqi",
+        "type": "tarball",
+        "url": "https://github.com/hasktorch/libtorch-nix/archive/d14b0fd10b96d192b92b8ccc7254ade4b3489331.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",
@@ -57,18 +69,6 @@
         "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
         "type": "tarball",
         "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "pytorch-world": {
-        "branch": "unstable",
-        "description": "nix scripts for pytorch-related libraries",
-        "homepage": "https://pytorch.org/",
-        "owner": "stites",
-        "repo": "pytorch-world",
-        "rev": "8942b2f8b16e59e1370134c4b56dcc91d9686a9e",
-        "sha256": "19rvsg2764mpz60y20da4vxwdk9ly5c5x98qdkjdrl7y1nbl5mhn",
-        "type": "tarball",
-        "url": "https://github.com/stites/pytorch-world/archive/8942b2f8b16e59e1370134c4b56dcc91d9686a9e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "stackage-nix": {


### PR DESCRIPTION
Changes:
- add flake support
- pytorch-world -> libtorch-nix
- add binary (for showcasing how this is hooked into a flake).

FIXMEs:
- I just hardcoded cudaSupport = false in the flake. probably I should figure out how to pass arguments in a flake-based project.
- the flake.lock should probably be replaced with something cached upstream -- I'm just reusing an lock from a different project. I started off reusing commits from niv but something went wrong and I wasn't pulling from cache. everything is still looking good on the niv setup, though.