### PR TITLE
 Fix CUDA 11 version to match libtorch-nix

### DIFF
--- a/nix/overlays/libtorch.nix
+++ b/nix/overlays/libtorch.nix
@@ -25,7 +25,7 @@ else if cudaSupport && cudaMajorVersion == "10" then
     torch_cuda = libtorch;
   }
 else if cudaSupport && cudaMajorVersion == "11" then
-  let libtorch = libtorchSrc.libtorch_cudatoolkit_11_0; in
+  let libtorch = libtorchSrc.libtorch_cudatoolkit_11_1; in
   {
     c10 = libtorch;
     torch = libtorch;


### PR DESCRIPTION
libtorch_cudatoolkit_11_0 -> libtorch_cudatoolkit_11_1

Attempting to use nix with cudaMajorVersion 11 would fail with a missing attribute error as libtorch-nix has 11.1 instead of 11.0 